### PR TITLE
Improve selector bucket sorting

### DIFF
--- a/src-tauri/src/db/database.rs
+++ b/src-tauri/src/db/database.rs
@@ -249,7 +249,7 @@ impl Database {
     pub fn get_all_active_files(&self) -> SqliteResult<Vec<File>> {
         let mut stmt = self
             .conn
-            .prepare("SELECT * FROM files WHERE is_deleted = 0")?;
+            .prepare("SELECT * FROM files WHERE is_deleted = 0 ORDER BY last_seen_at DESC")?;
         let rows = stmt.query_map([], |row| Self::map_row_to_file(row))?;
         let mut files = Vec::new();
         for row in rows {


### PR DESCRIPTION
## Summary
- score every file in a selector bucket, sort by score/recency, and only then truncate the bucket results
- read active files ordered by `last_seen_at` so the selector sees newer entries first
- extend selector tests with richer helpers and a regression case covering the new sorting behaviour

## Testing
- `cargo test selector` *(fails: crate does not compile on linux because Windows-specific modules and other test helpers are missing on this platform)*