### PR TITLE
Increase selector bucket capacity defaults

### DIFF
--- a/src-tauri/SELECTOR.md
+++ b/src-tauri/SELECTOR.md
@@ -61,31 +61,31 @@ score = 0.45*norm(size) + 0.25*norm(age_days)
 #### Screenshots
 
 - **Criteria**: Name contains "screenshot" OR under `/Screenshots/`
-- **Cap**: 5 files per day
+- **Cap**: 30 files per day
 - **Rationale**: Screenshots are often temporary and accumulate quickly
 
 #### Big Downloads
 
 - **Criteria**: Under Downloads, size > 100MB, unopened OR age > 30d
-- **Cap**: 3 files per day
+- **Cap**: 30 files per day
 - **Rationale**: Large downloads consume significant space
 
 #### Old Desktop
 
 - **Criteria**: Under Desktop, age > 14d
-- **Cap**: 2 files per day
+- **Cap**: 30 files per day
 - **Rationale**: Desktop files are often temporary
 
 #### Duplicates
 
 - **Criteria**: Identical SHA1 hash (skip files > 2GB)
-- **Cap**: 2 files per day
+- **Cap**: 30 files per day
 - **Rationale**: Duplicates waste space unnecessarily
 
 ### Daily Limits
 
 - **Per Bucket**: Individual caps for each bucket type
-- **Total Daily**: Maximum 12 candidates per day (mix cap)
+- **Total Daily**: Maximum 30 candidates per day (mix cap)
 - **Configurable**: Limits can be adjusted via `BucketConfig`
 
 ## API Reference
@@ -162,11 +162,11 @@ Preview hints provide quick context about why a file was selected:
 
 ```rust
 struct BucketConfig {
-    screenshots_max: usize,    // Default: 5
-    big_downloads_max: usize,  // Default: 3
-    old_desktop_max: usize,    // Default: 2
-    duplicates_max: usize,     // Default: 2
-    daily_total_max: usize,    // Default: 12
+    screenshots_max: usize,    // Default: 30
+    big_downloads_max: usize,  // Default: 30
+    old_desktop_max: usize,    // Default: 30
+    duplicates_max: usize,     // Default: 30
+    daily_total_max: usize,    // Default: 30
 }
 ```
 

--- a/src-tauri/src/selector/mod.rs
+++ b/src-tauri/src/selector/mod.rs
@@ -19,11 +19,11 @@ pub struct BucketConfig {
 impl Default for BucketConfig {
     fn default() -> Self {
         Self {
-            screenshots_max: 5,
-            big_downloads_max: 3,
-            old_desktop_max: 2,
-            duplicates_max: 2,
-            daily_total_max: 12, // Mix cap per day
+            screenshots_max: 30,
+            big_downloads_max: 30,
+            old_desktop_max: 30,
+            duplicates_max: 30,
+            daily_total_max: 30, // Mix cap per day
         }
     }
 }

--- a/src-tauri/src/selector/tests.rs
+++ b/src-tauri/src/selector/tests.rs
@@ -381,6 +381,16 @@ mod tests {
     }
 
     #[test]
+    fn test_bucket_config_default_limits() {
+        let config = BucketConfig::default();
+        assert_eq!(config.screenshots_max, 30);
+        assert_eq!(config.big_downloads_max, 30);
+        assert_eq!(config.old_desktop_max, 30);
+        assert_eq!(config.duplicates_max, 30);
+        assert_eq!(config.daily_total_max, 30);
+    }
+
+    #[test]
     fn test_explicit_limit_overrides_daily_cap() {
         let mut selector = FileSelector::new();
         let config = BucketConfig {


### PR DESCRIPTION
## Summary
- raise the default per-bucket and total caps in `BucketConfig` to 30 items
- document the higher caps in the selector design notes
- add a regression test that asserts the new default limits

## Testing
- `cargo test selector` *(fails: existing linux build errors in unrelated modules)*