### PR TITLE
Added apps/desktop/ui/src/lib/fileIcons.tsx with a centralized extension icon map

### DIFF
--- a/apps/desktop/ui/src/components/FileRow.tsx
+++ b/apps/desktop/ui/src/components/FileRow.tsx
@@ -1,0 +1,90 @@
+import type { ReactNode } from "react"
+import { Folder } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { FileIcon, getExtensionFromPath } from "@/lib/fileIcons"
+
+function sanitizePath(value?: string | null): string | undefined {
+  if (!value) return undefined;
+
+  if (value.startsWith("\\\\?\\")) {
+    const rest = value.slice(4); 
+
+    if (rest.startsWith("UNC\\")) {
+      return `\\\\${rest.slice(4)}`;
+    }
+
+    return rest;
+  }
+
+  return value;
+}
+function displayName(input: string, maxLength = 60): string {
+  const sanitized = sanitizePath(input) ?? input
+  const parts = sanitized.split(/[\\/]/)
+  const name = parts.pop() ?? sanitized
+  if (name.length <= maxLength) return name || sanitized
+  return `${name.slice(0, maxLength - 1)}…`
+}
+
+export type UiFile = {
+  id?: number | string
+  name: string
+  path: string
+  mime?: string | null
+  ext?: string | null
+  isDirectory?: boolean
+}
+
+export interface FileRowProps {
+  file: UiFile
+  subtitle?: ReactNode
+  endAccessory?: ReactNode
+  className?: string
+  onClick?: () => void
+  children?: ReactNode
+}
+
+export function FileRow({
+  file,
+  subtitle,
+  endAccessory,
+  className,
+  onClick,
+  children,
+}: FileRowProps) {
+  const ext = file.ext ?? (file.isDirectory ? null : getExtensionFromPath(file.path))
+  const name = displayName(file.name)
+  const subtitleContent =
+    typeof subtitle === "string"
+      ? (() => {
+          const clean = sanitizePath(subtitle) ?? subtitle
+          return clean.length > 80 ? `${clean.slice(0, 79)}…` : clean
+        })()
+      : subtitle
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 rounded-md px-3 py-2 transition hover:bg-muted/40",
+        onClick ? "cursor-pointer" : "",
+        className,
+      )}
+      onClick={onClick}
+    >
+      {file.isDirectory ? (
+        <Folder className="h-5 w-5 text-muted-foreground" />
+      ) : (
+        <FileIcon ext={ext} mime={file.mime} className="h-5 w-5 text-muted-foreground" />
+      )}
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm text-foreground">{name}</div>
+        {subtitleContent ? (
+          <div className="truncate text-xs text-muted-foreground">{subtitleContent}</div>
+        ) : null}
+      </div>
+      {endAccessory}
+      {children}
+    </div>
+  )
+}

--- a/apps/desktop/ui/src/components/folders/DirectoryPanel.tsx
+++ b/apps/desktop/ui/src/components/folders/DirectoryPanel.tsx
@@ -1,6 +1,42 @@
 import * as React from "react"
 
+import { FileRow } from "@/components/FileRow"
+import { getExtensionFromPath } from "@/lib/fileIcons"
 import type { DirectoryEntry } from "@/types/folders"
+
+function formatBytes(value: number) {
+  if (!value) return "0 B"
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'] as const
+  const exponent = Math.min(Math.floor(Math.log(value) / Math.log(1024)), units.length - 1)
+  const size = value / Math.pow(1024, exponent)
+  return `${size.toFixed(size >= 10 ? 0 : 1)} ${units[exponent]}`
+}
+
+function formatTimestamp(value?: number) {
+  if (!value) return ''
+  try {
+    const date = new Date(value * 1000)
+    return new Intl.DateTimeFormat(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(date)
+  } catch {
+    return ''
+  }
+}
+
+function formatParentDir(path: string | null | undefined): string | undefined {
+  if (!path) return undefined
+  const sanitized = path.startsWith('\\?\\') ? path.slice(4) : path
+  const trimmed = sanitized.replace(/[\\/]+$/, '')
+  const parts = trimmed.split(/[\\/]/).filter(Boolean)
+  if (!parts.length) return sanitized
+  parts.pop()
+  return parts.pop()
+}
 
 interface DirectoryPanelProps {
   entries: DirectoryEntry[]
@@ -11,130 +47,183 @@ interface DirectoryPanelProps {
   onOpenEntry?: (entry: DirectoryEntry) => void
 }
 
-function formatBytes(value: number) {
-  if (!value) return "0 B"
-  const units = ["B", "KB", "MB", "GB", "TB"] as const
-  const exponent = Math.min(Math.floor(Math.log(value) / Math.log(1024)), units.length - 1)
-  const size = value / Math.pow(1024, exponent)
-  return `${size.toFixed(size >= 10 ? 0 : 1)} ${units[exponent]}`
-}
-
-function formatTimestamp(value?: number) {
-  if (!value) return "";
-  try {
-    const date = new Date(value * 1000)
-    return new Intl.DateTimeFormat(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    }).format(date)
-  } catch {
-    return ""
-  }
-}
-
 export function DirectoryPanel({
+
   entries,
+
   loading,
+
   error,
+
   folderName,
+
   onRetry,
+
   onOpenEntry,
+
 }: DirectoryPanelProps) {
+
   const directories = React.useMemo(
+
     () => entries.filter((entry) => entry.kind === "dir"),
+
     [entries]
+
   )
+
   const files = React.useMemo(
+
     () => entries.filter((entry) => entry.kind !== "dir"),
+
     [entries]
+
   )
+
+
 
   if (loading) {
+
     return (
+
       <div className="flex min-h-[160px] items-center justify-center rounded-xl border border-dashed border-border/80 bg-muted/40 text-sm text-muted-foreground">
+
         Loading directory�
+
       </div>
+
     )
+
   }
+
+
 
   if (error) {
+
     return (
+
       <div className="flex min-h-[160px] flex-col items-center justify-center gap-3 rounded-xl border border-destructive/30 bg-destructive/5 px-4 py-6 text-center">
+
         <p className="text-sm text-destructive">{error}</p>
+
         {onRetry ? (
+
           <button
+
             type="button"
+
             onClick={onRetry}
+
             className="rounded-md bg-destructive px-3 py-1.5 text-sm font-medium text-destructive-foreground shadow-sm transition hover:bg-destructive/90"
+
           >
+
             Try again
+
           </button>
+
         ) : null}
+
       </div>
+
     )
+
   }
+
+
 
   if (!entries.length) {
+
     return (
+
       <div className="flex min-h-[160px] flex-col items-center justify-center rounded-xl border border-dashed border-border/80 bg-muted/40 px-4 py-6 text-center text-sm text-muted-foreground">
+
         {folderName ? (
+
           <>
+
             <p>No items in <span className="font-medium text-foreground">{folderName}</span>.</p>
+
             <p className="mt-2">Start a scan to collect metadata.</p>
+
           </>
+
         ) : (
+
           <p>Select a folder to view its contents.</p>
+
         )}
+
       </div>
+
     )
+
   }
 
-  const renderEntry = (entry: DirectoryEntry) => (
-    <div
-      key={entry.path}
-      className="grid grid-cols-[minmax(0,1fr)_110px_140px] items-center gap-3 rounded-lg px-3 py-2 text-sm transition hover:bg-muted/60"
-    >
-      <div className="flex flex-col">
-        <span className="font-medium text-foreground" title={entry.path}>
-          {entry.name}
-        </span>
-        <span className="text-xs text-muted-foreground" title={entry.path}>
-          {entry.path}
-        </span>
-      </div>
-      <span className="text-xs tabular-nums text-muted-foreground">
-        {entry.kind === "dir" ? "�" : formatBytes(entry.size)}
-      </span>
-      <div className="flex items-center justify-end gap-2">
-        <span className="text-xs text-muted-foreground">{formatTimestamp(entry.modified)}</span>
-        <button
-          type="button"
-          onClick={() => onOpenEntry?.(entry)}
-          className="rounded-md border border-border px-2 py-1 text-xs font-medium text-foreground transition hover:bg-accent"
-        >
-          Open
-        </button>
-       
-      </div>
-    </div>
-  )
 
-  const Section = ({ title, children }: { title: string; children: React.ReactNode }) => (
-    <div className="flex flex-col gap-1">
-      <div className="pl-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-        {title}
-      </div>
-      <div className="flex flex-col gap-1">{children}</div>
-    </div>
-  )
 
+  const renderEntry = (entry: DirectoryEntry) => {
+  const isDirectory = entry.kind === "dir"
+  const sizeLabel = isDirectory ? "�" : formatBytes(entry.size)
+  const ext = isDirectory ? null : getExtensionFromPath(entry.name)
   return (
-    <div className="flex flex-col gap-4 rounded-xl border border-border/60 bg-background px-3 py-4">
-      {directories.length ? <Section title="Folders">{directories.map(renderEntry)}</Section> : null}
-      {files.length ? <Section title="Files">{files.map(renderEntry)}</Section> : null}
-    </div>
+    <FileRow
+      key={entry.path}
+      file={{
+        id: entry.path,
+        name: entry.name,
+        path: entry.path,
+        ext,
+        isDirectory,
+      }}
+      subtitle={formatParentDir(entry.path)}
+      endAccessory={
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <span className="tabular-nums">{sizeLabel}</span>
+          <span>{formatTimestamp(entry.modified)}</span>
+          <button
+            type="button"
+            onClick={() => onOpenEntry?.(entry)}
+            className="rounded-md border border-border px-2 py-1 text-xs font-medium text-foreground transition hover:bg-accent"
+          >
+            Open
+          </button>
+        </div>
+      }
+    />
   )
 }
+const Section = ({ title, children }: { title: string; children: React.ReactNode }) => (
+
+    <div className="flex flex-col gap-1">
+
+      <div className="pl-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+
+        {title}
+
+      </div>
+
+      <div className="flex flex-col gap-1">{children}</div>
+
+    </div>
+
+  )
+
+
+
+  return (
+
+    <div className="flex flex-col gap-4 rounded-xl border border-border/60 bg-background px-3 py-4">
+
+      {directories.length ? <Section title="Folders">{directories.map(renderEntry)}</Section> : null}
+
+      {files.length ? <Section title="Files">{files.map(renderEntry)}</Section> : null}
+
+    </div>
+
+  )
+
+}
+
+
+
+

--- a/apps/desktop/ui/src/lib/fileIcons.tsx
+++ b/apps/desktop/ui/src/lib/fileIcons.tsx
@@ -1,0 +1,90 @@
+import type { ReactElement } from "react"
+import {
+  File as IconFile,
+  FileArchive,
+  FileAudio,
+  FileCode,
+  FileCog,
+  FileImage,
+  FilePenLine,
+  FileSpreadsheet,
+  FileText,
+  FileType,
+  FileVideo,
+  Image as ImageIcon,
+} from "lucide-react"
+
+type IconFactory = (props: { className?: string }) => ReactElement
+
+const mapByExt: Record<string, IconFactory> = {
+  pdf: (props) => <FileText {...props} />,
+  png: (props) => <FileImage {...props} />,
+  jpg: (props) => <FileImage {...props} />,
+  jpeg: (props) => <FileImage {...props} />,
+  gif: (props) => <FileImage {...props} />,
+  webp: (props) => <FileImage {...props} />,
+  svg: (props) => <ImageIcon {...props} />,
+  mp4: (props) => <FileVideo {...props} />,
+  mov: (props) => <FileVideo {...props} />,
+  mkv: (props) => <FileVideo {...props} />,
+  mp3: (props) => <FileAudio {...props} />,
+  wav: (props) => <FileAudio {...props} />,
+  flac: (props) => <FileAudio {...props} />,
+  zip: (props) => <FileArchive {...props} />,
+  "7z": (props) => <FileArchive {...props} />,
+  rar: (props) => <FileArchive {...props} />,
+  exe: (props) => <FileCog {...props} />,
+  dmg: (props) => <FileCog {...props} />,
+  msu: (props) => <FileCog {...props} />,
+  sh: (props) => <FileCode {...props} />,
+  js: (props) => <FileCode {...props} />,
+  ts: (props) => <FileCode {...props} />,
+  jsx: (props) => <FileCode {...props} />,
+  tsx: (props) => <FileCode {...props} />,
+  py: (props) => <FileCode {...props} />,
+  rs: (props) => <FileCode {...props} />,
+  go: (props) => <FileCode {...props} />,
+  css: (props) => <FileCode {...props} />,
+  html: (props) => <FileCode {...props} />,
+  doc: (props) => <FilePenLine {...props} />,
+  docx: (props) => <FilePenLine {...props} />,
+  ppt: (props) => <FileType {...props} />,
+  pptx: (props) => <FileType {...props} />,
+  xls: (props) => <FileSpreadsheet {...props} />,
+  xlsx: (props) => <FileSpreadsheet {...props} />,
+}
+
+export function getExtensionFromPath(path?: string | null): string | null {
+  if (!path) return null
+  const normalized = path.replace(/\\/g, "/")
+  const segment = normalized.split("/").pop() ?? ""
+  const lastDot = segment.lastIndexOf(".")
+  if (lastDot <= 0) return null
+  const ext = segment.slice(lastDot + 1).toLowerCase()
+  return ext || null
+}
+
+export function FileIcon({
+  ext,
+  mime,
+  className = "h-5 w-5",
+}: {
+  ext?: string | null
+  mime?: string | null
+  className?: string
+}) {
+  const lowerExt = (ext ?? "").toLowerCase()
+  if (lowerExt && mapByExt[lowerExt]) {
+    return mapByExt[lowerExt]({ className })
+  }
+
+  if (mime?.startsWith("image/")) return <FileImage className={className} />
+  if (mime?.startsWith("video/")) return <FileVideo className={className} />
+  if (mime?.startsWith("audio/")) return <FileAudio className={className} />
+  if (mime === "application/zip" || mime?.includes("compressed")) {
+    return <FileArchive className={className} />
+  }
+  if (mime?.includes("pdf")) return <FileText className={className} />
+
+  return <IconFile className={className} />
+}

--- a/apps/desktop/ui/src/main.tsx
+++ b/apps/desktop/ui/src/main.tsx
@@ -7,7 +7,7 @@ import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-      <ThemeProvider defaultTheme="system" storageKey="vite-ui-theme">
+      <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
     <App />
     </ThemeProvider>
   </StrictMode>,

--- a/apps/desktop/ui/src/pages/activity.tsx
+++ b/apps/desktop/ui/src/pages/activity.tsx
@@ -1,13 +1,17 @@
 ﻿import * as React from "react"
 import { useNavigate } from "react-router-dom"
 
+import { FileRow } from "@/components/FileRow"
 import { Button } from "@/components/ui/button"
+import { getExtensionFromPath } from "@/lib/fileIcons"
 import { formatBytes } from "@/hooks/useGauge"
 import { useFolderStore } from "@/store/folder-store"
 import type { DuplicateGroup } from "@/lib/ipc"
 import type { ScanCandidate } from "@/types/folders"
 
 type TabKey = "duplicates" | "downloads" | "screenshots"
+
+
 
 type CandidateGroup = {
   key: string
@@ -16,332 +20,715 @@ type CandidateGroup = {
   files: ScanCandidate[]
 }
 
+function formatParentDir(path: string): string | undefined {
+  if (!path) return undefined
+  const sanitized = path.startsWith('\\?\\') ? path.slice(4) : path
+  const parts = sanitized.split(/[\\/]/)
+  if (parts.length <= 1) return sanitized
+  parts.pop()
+  return parts.pop() ?? sanitized
+}
+
+function formatDirectoryName(path: string | null | undefined): string {
+  if (!path) return "Unknown location"
+  const sanitized = path.startsWith('\\?\\') ? path.slice(4) : path
+  const trimmed = sanitized.replace(/[\\/]+$/, '')
+  const parts = trimmed.split(/[\\/]/).filter(Boolean)
+  if (!parts.length) return sanitized || 'Unknown location'
+  return parts.pop() ?? sanitized
+}
+
+
+
 const TABS: { id: TabKey; label: string }[] = [
+
   { id: "duplicates", label: "Duplicates" },
+
   { id: "downloads", label: "Large Downloads" },
+
   { id: "screenshots", label: "Screenshots" },
+
 ]
 
+
+
 export function Activity() {
+
   const navigate = useNavigate()
+
   const [activeTab, setActiveTab] = React.useState<TabKey>("duplicates")
 
+
+
   const selectedFolderId = useFolderStore((state) => state.selectedFolderId)
+
   const folders = useFolderStore((state) => state.folders)
+
   const candidates = useFolderStore((state) => state.candidates)
+
   const duplicateGroups = useFolderStore((state) => state.duplicates.groups)
+
   const duplicatesLoading = useFolderStore((state) => state.duplicates.loading)
+
   const duplicateError = useFolderStore((state) => state.duplicates.error)
+
   const loadCandidates = useFolderStore((state) => state.loadCandidates)
+
   const loadDuplicateGroups = useFolderStore((state) => state.loadDuplicateGroups)
+
   const openInSystem = useFolderStore((state) => state.openInSystem)
+
   const selectFolder = useFolderStore((state) => state.selectFolder)
+
   const stageFilesByIds = useFolderStore((state) => state.stageFilesByIds)
 
+
+
   const selectedFolder = React.useMemo(() => {
+
     return folders.find((folder) => folder.id === selectedFolderId) ?? null
+
   }, [folders, selectedFolderId])
 
+
+
   React.useEffect(() => {
+
     if (!selectedFolderId && folders.length > 0) {
+
       void selectFolder(folders[0].id)
+
       return
+
     }
+
+
 
     if (selectedFolderId) {
+
       void loadCandidates()
+
       void loadDuplicateGroups()
+
     }
+
   }, [folders, loadCandidates, loadDuplicateGroups, selectFolder, selectedFolderId])
 
+
+
   const largeDownloadGroups = React.useMemo(() => {
+
     return groupCandidatesByParent(candidates, "big_download")
+
   }, [candidates])
+
+
 
   const screenshotGroups = React.useMemo(() => {
+
     return groupCandidatesByParent(candidates, "screenshot")
+
   }, [candidates])
 
+
+
   React.useEffect(() => {
+
     if (activeTab !== "duplicates") return
+
     if (duplicateGroups.length === 0 && !duplicatesLoading && !duplicateError) {
+
       if (largeDownloadGroups.length) {
+
         setActiveTab("downloads")
+
       } else if (screenshotGroups.length) {
+
         setActiveTab("screenshots")
+
       }
+
     }
+
   }, [activeTab, duplicateGroups.length, duplicatesLoading, duplicateError, largeDownloadGroups.length, screenshotGroups.length])
 
+
+
   const handleStageDuplicateGroup = React.useCallback(
+
     async (group: DuplicateGroup) => {
+
       const fileIds = group.files
+
         .filter((file) => !file.isStaged && Number.isFinite(file.id) && file.id > 0)
+
         .map((file) => file.id)
+
       if (!fileIds.length) return
+
       await stageFilesByIds(fileIds)
+
     },
+
     [stageFilesByIds]
+
   )
+
+
 
   const handleStageCandidateGroup = React.useCallback(
+
     async (group: CandidateGroup) => {
+
       const fileIds = group.files
+
         .map((file) => file.fileId)
+
         .filter((id) => Number.isFinite(id) && id > 0)
+
       if (!fileIds.length) return
+
       await stageFilesByIds(fileIds)
+
     },
+
     [stageFilesByIds]
+
   )
+
+
 
   const handleOpenPath = React.useCallback(
+
     (path: string) => {
+
       if (!path) return
+
       void openInSystem(path)
+
     },
+
     [openInSystem]
+
   )
+
+
 
   if (!selectedFolder) {
+
     return (
+
       <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col items-center justify-center gap-4 px-4 py-6 text-center">
+
         <div className="space-y-1">
+
           <h2 className="text-lg font-semibold text-foreground">No folder selected</h2>
+
           <p className="text-sm text-muted-foreground">
+
             Pick a watched folder on the Home screen to inspect its contents and sync activity.
+
           </p>
+
         </div>
+
         <Button type="button" onClick={() => navigate("/")}>
+
           Go to watched folders
+
         </Button>
+
       </div>
+
     )
+
   }
 
+
+
   return (
+
     <div className="mx-auto flex w-full max-w-4xl flex-col gap-5 px-4 py-6">
+
       <header className="space-y-1">
+
         <h1 className="text-xl font-semibold text-foreground">{selectedFolder.name}</h1>
+
         <p className="truncate text-sm text-muted-foreground">{selectedFolder.path}</p>
+
       </header>
 
+
+
       <nav className="flex gap-2 text-sm" aria-label="Candidate buckets">
+
         {TABS.map((tab) => {
+
           const isActive = activeTab === tab.id
+
           return (
+
             <button
+
               key={tab.id}
+
               type="button"
+
               onClick={() => setActiveTab(tab.id)}
+
               className={`rounded-full px-3 py-1 transition ${isActive ? "bg-primary text-primary-foreground shadow" : "bg-muted text-muted-foreground hover:bg-muted/80"}`}
+
             >
+
               {tab.label}
+
             </button>
+
           )
+
         })}
+
       </nav>
 
+
+
       <section className="space-y-4">
+
         {activeTab === "duplicates" ? (
+
           <DuplicateGroupsView
+
             groups={duplicateGroups}
+
             loading={duplicatesLoading}
+
             error={duplicateError}
+
             onStageGroup={handleStageDuplicateGroup}
+
             onOpenPath={handleOpenPath}
+
           />
+
         ) : null}
+
         {activeTab === "downloads" ? (
+
           <CandidateGroupsView
+
             groups={largeDownloadGroups}
+
             emptyLabel="No large downloads flagged yet."
+
             onStageGroup={handleStageCandidateGroup}
+
             onOpenPath={handleOpenPath}
+
           />
+
         ) : null}
+
         {activeTab === "screenshots" ? (
+
           <CandidateGroupsView
+
             groups={screenshotGroups}
+
             emptyLabel="No screenshots identified yet."
+
             onStageGroup={handleStageCandidateGroup}
+
             onOpenPath={handleOpenPath}
+
           />
+
         ) : null}
+
       </section>
+
     </div>
+
   )
+
 }
+
+
 
 export default Activity
 
+
+
 function DuplicateGroupsView({
+
   groups,
+
   loading,
+
   error,
+
   onStageGroup,
+
   onOpenPath,
+
 }: {
+
   groups: DuplicateGroup[]
+
   loading: boolean
+
   error: string | null
+
   onStageGroup: (group: DuplicateGroup) => void | Promise<void>
+
   onOpenPath: (path: string) => void
+
 }) {
+
   if (loading) {
+
     return (
+
       <div className="rounded-lg border border-border/50 bg-muted/30 px-4 py-6 text-sm text-muted-foreground">
-        Loading duplicate groups…
+
+        Loading duplicate groups.
+
       </div>
+
     )
+
   }
+
+
 
   if (error) {
+
     return (
+
       <div className="rounded-lg border border-destructive/40 bg-destructive/10 px-4 py-6 text-sm text-destructive">
+
         {error}
+
       </div>
+
     )
+
   }
+
+
 
   if (!groups.length) {
+
     return (
+
       <div className="rounded-lg border border-border/40 bg-muted/20 px-4 py-6 text-sm text-muted-foreground">
+
         No duplicate groups available yet. Run a scan to refresh suggestions.
+
       </div>
+
     )
+
   }
 
+
+
   return (
+
     <div className="space-y-4">
+
       {groups.map((group) => {
+
         const unstaged = group.files.filter((file) => !file.isStaged)
+
         const totalBytes = group.files.reduce((sum, file) => sum + file.sizeBytes, 0)
 
+
+
         return (
+
           <div key={group.hash} className="rounded-lg border border-border/60 bg-background px-4 py-3">
+
             <div className="flex flex-wrap items-center justify-between gap-3">
+
               <div>
+
                 <h3 className="text-sm font-semibold text-foreground">{group.count} duplicate{group.count === 1 ? "" : "s"}</h3>
+
                 <p className="text-xs text-muted-foreground">Total size {formatBytes(totalBytes)}</p>
+
               </div>
-              <div className="flex gap-2">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  disabled={!unstaged.length}
-                  onClick={() => void onStageGroup(group)}
-                >
-                  {unstaged.length ? `Stage ${unstaged.length}` : "All staged"}
-                </Button>
-              </div>
+
+              <Button
+
+                variant="outline"
+
+                size="sm"
+
+                disabled={!unstaged.length}
+
+                onClick={() => void onStageGroup(group)}
+
+              >
+
+                {unstaged.length ? `Stage ${unstaged.length}` : "All staged"}
+
+              </Button>
+
             </div>
 
+
+
             <ul className="mt-3 space-y-2">
-              {group.files.map((file) => (
-                <li key={file.id} className="flex flex-wrap items-center gap-3 text-sm">
-                  <div className="min-w-0 flex-1">
-                    <p className="truncate text-foreground" title={file.path}>
-                      {file.path.split(/[\\/]/).pop()?.slice(0, 50) ?? file.path.slice(0, 2) + "..."} 
-                    </p>
-                    {/* <p className="truncate text-xs text-muted-foreground" title={file.path}>
-                      {file.parentDir}
-                    </p> */}
-                  </div>
-                  <span className="text-xs text-muted-foreground">{formatBytes(file.sizeBytes)}</span>
-                  <Button variant="ghost" size="sm" onClick={() => onOpenPath(file.path)}>
-                    Open
-                  </Button>
-                </li>
-              ))}
+
+              {group.files.map((file) => {
+
+                const name = file.path.split(/[\/]/).pop() ?? file.path
+
+                return (
+
+                  <li key={file.id}>
+
+                    <FileRow
+
+                      file={{
+
+                        id: file.id,
+
+                        name,
+
+                        path: file.path,
+
+                        ext: getExtensionFromPath(file.path),
+
+                      }}
+
+                      subtitle={formatParentDir(file.parentDir)}
+
+                      endAccessory={
+
+                        <div className="flex items-center gap-2">
+
+                          <span className="text-xs text-muted-foreground tabular-nums">
+
+                            {formatBytes(file.sizeBytes)}
+
+                          </span>
+
+                          <Button variant="ghost" size="sm" onClick={() => onOpenPath(file.path)}>
+
+                            Open
+
+                          </Button>
+
+                        </div>
+
+                      }
+
+                    />
+
+                  </li>
+
+                )
+
+              })}
+
             </ul>
+
           </div>
+
         )
+
       })}
+
     </div>
+
   )
+
 }
 
 function CandidateGroupsView({
+
   groups,
+
   emptyLabel,
+
   onStageGroup,
+
   onOpenPath,
+
 }: {
+
   groups: CandidateGroup[]
+
   emptyLabel: string
+
   onStageGroup: (group: CandidateGroup) => void | Promise<void>
+
   onOpenPath: (path: string) => void
+
 }) {
+
   if (!groups.length) {
+
     return (
+
       <div className="rounded-lg border border-border/40 bg-muted/20 px-4 py-6 text-sm text-muted-foreground">
+
         {emptyLabel}
+
       </div>
+
     )
+
   }
 
+
+
   return (
+
     <div className="space-y-4">
+
       {groups.map((group) => (
+
         <div key={group.key} className="rounded-lg border border-border/60 bg-background px-4 py-3">
+
           <div className="flex flex-wrap items-center justify-between gap-3">
+
             <div>
+
               <h3 className="text-sm font-semibold text-foreground" title={group.label}>
-                {group.label.slice(0, 30) + "..." || "Unknown location"}
+
+                {formatDirectoryName(group.label)}
+
               </h3>
+
               <p className="text-xs text-muted-foreground">
-                {group.files.length} item{group.files.length === 1 ? "" : "s"} • {formatBytes(group.totalBytes)}
+
+                {group.files.length} item{group.files.length === 1 ? "" : "s"} � {formatBytes(group.totalBytes)}
+
               </p>
+
             </div>
+
             <Button variant="outline" size="sm" onClick={() => void onStageGroup(group)}>
+
               Stage group
+
             </Button>
+
           </div>
 
+
+
           <ul className="mt-3 space-y-2">
-            {group.files.map((file) => (
-              <li key={file.fileId} className="flex flex-wrap items-center gap-3 text-sm">
-                <div className="min-w-0 flex-1">
-                  <p className="truncate text-foreground" title={file.path}>
-                    {file.path.split(/[\\/]/).pop() ?? file.path.slice(0, 2)}
-                  </p>
-                  {/* <p className="truncate text-xs text-muted-foreground" title={file.path}>
-                    {file.parentDir.slice(0, 2)}
-                  </p> */}
-                </div>
-                <span className="text-xs text-muted-foreground">{formatBytes(file.sizeBytes)}</span>
-                <Button variant="ghost" size="sm" onClick={() => onOpenPath(file.path)}>
-                  Open
-                </Button>
-              </li>
-            ))}
+
+            {group.files.map((file) => {
+
+              const name = file.path.split(/[\/]/).pop() ?? file.path
+
+              return (
+
+                <li key={file.fileId}>
+
+                  <FileRow
+
+                    file={{
+
+                      id: file.fileId,
+
+                      name,
+
+                      path: file.path,
+
+                      ext: getExtensionFromPath(file.path),
+
+                    }}
+
+                    subtitle={formatParentDir(file.parentDir)}
+
+                    endAccessory={
+
+                      <div className="flex items-center gap-2">
+
+                        <span className="text-xs text-muted-foreground tabular-nums">
+
+                          {formatBytes(file.sizeBytes)}
+
+                        </span>
+
+                        <Button variant="ghost" size="sm" onClick={() => onOpenPath(file.path)}>
+
+                          Open
+
+                        </Button>
+
+                      </div>
+
+                    }
+
+                  />
+
+                </li>
+
+              )
+
+            })}
+
           </ul>
+
         </div>
+
       ))}
+
     </div>
+
   )
+
 }
 
 function groupCandidatesByParent(candidates: ScanCandidate[], reason: string): CandidateGroup[] {
+
   const buckets = new Map<string, CandidateGroup>()
+
   for (const candidate of candidates) {
+
     if (candidate.reason !== reason) continue
+
     const key = candidate.parentDir || "(unknown)"
+
     const existing = buckets.get(key)
+
     if (existing) {
+
       existing.files.push(candidate)
+
       existing.totalBytes += candidate.sizeBytes
+
     } else {
+
       buckets.set(key, {
+
         key: `${reason}:${key}`,
+
         label: key,
+
         totalBytes: candidate.sizeBytes,
+
         files: [candidate],
+
       })
+
     }
+
   }
+
   const groups = Array.from(buckets.values())
+
   groups.sort((a, b) => b.totalBytes - a.totalBytes)
+
   return groups
+
 }
+
+
+


### PR DESCRIPTION
Added apps/desktop/ui/src/lib/fileIcons.tsx with a centralized extension→icon map, MIME fallbacks, and a getExtensionFromPath helper so every file can resolve its icon consistently.

Introduced apps/desktop/ui/src/components/FileRow.tsx, a reusable row that renders the appropriate icon (folder vs. file), primary text, optional subtitle, and right-side actions.